### PR TITLE
docs: apply sentence case to all headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This GitHub Action installs the Alpacon CLI in your workflow environment.
 - Installs Alpacon CLI automatically in your workflow
 - Skips installation if CLI is already present
 
-## Usage Example (workflow)
+## Usage examples
 
 ```yaml
 jobs:


### PR DESCRIPTION
Apply terminology and formatting consistency across all actions This PR applies the same changes from https://github.com/alpacax/alpacon-websh-action/pull/2 to all other actions for consistency.

## Changes
- Apply sentence case to all headings (e.g., "Usage Example" → "Usage examples", "Important Notes" → "Important notes")