### PR TITLE
ci: bump node20 actions (checkout v4→v6)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Test Alpacon CLI Installation
         uses: ./
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Pre-install Alpacon CLI (simulate already installed)
         run: |


### PR DESCRIPTION
## Summary
GitHub blocks Node 20 runtime actions starting 2026-06-16. This bumps `actions/checkout` used in this repo's workflow to the Node 24 runtime version.

## Changes
### .github/workflows/test.yml
- `actions/checkout@v4` (Node 20) → `@v6` (Node 24)

> The composite action definition (`action.yml`) does not use `actions/checkout`, so consumers that reference this action via `@v1` are unaffected. Only the test workflow is updated.

## Test plan
- [ ] PR CI (test.yml) passes
